### PR TITLE
refactor(ci): rename 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,30 +1,40 @@
-# Shinigami Pipeline
+# 12th Division Pipeline
 
-GitHub Actions CI/CD workflows named after Gotei 13 captains from BLEACH.
+GitHub Actions CI/CD workflows named after 12th Division captains and members from BLEACH.
+The 12th Division is the Shinigami Research and Development Institute — Calendula (Despair in Your Heart).
 
 ## Workflows
 
 | Captain | File | Division | Role |
 |---------|------|----------|------|
-| **Aizen** | `aizen.yml` | 5th (Sacrifice) | Orchestrator: calls Kaname + Gin in parallel, then Kyoraku, then gate |
-| **Kaname** | `kaname.yml` | 9th (Oblivion) | CI: Ruff, Black, isort, pytest |
-| **Gin** | `gin.yml` | 3rd (Despair) | Security: Hadolint, Checkov, Trivy config scan, Bandit |
-| **Kyoraku** | `kyoraku.yml` | 1st (Truth and Innocence) | Buildah, Cosign, Trivy image scan, semver release |
-| **Yoruichi** | `yoruichi.yml` | 2nd (Seek Nothing) | Post-CI: generates STATUS.md, updates README badges |
-| **Mayuri** | `mayuri.yml` | 12th (R&D) | Dotfiles watcher: polls `borninthedark/dotfiles`, triggers Aizen on change |
+| **Urahara** | `urahara.yml` | 12th (Despair in Your Heart) | Orchestrator: calls Hikifune + Uhin in parallel, then Hiyori, then gate |
+| **Hikifune** | `hikifune.yml` | 12th (Despair in Your Heart) | CI: Ruff, Black, isort, pytest |
+| **Uhin** | `uhin.yml` | 12th (Despair in Your Heart) | Security: Hadolint, Checkov, Trivy config scan, Bandit |
+| **Hiyori** | `hiyori.yml` | 12th (Despair in Your Heart) | Build, Cosign, Trivy image scan, semver release |
+| **Nemu** | `nemu.yml` | 12th (Despair in Your Heart) | Post-CI: generates STATUS.md |
+| **Mayuri** | `mayuri.yml` | 12th (Despair in Your Heart) | Dotfiles watcher: polls `borninthedark/dotfiles`, triggers Urahara on change |
+
+## Captains
+
+| Captain | Tenure | Notes |
+|---------|--------|-------|
+| Uhin Zenjoji | 1002 A.D. - ? | Deceased — founding captain |
+| Kirio Hikifune | ? - 1891 A.D. | Promoted to Royal Guard (Squad Zero) |
+| Kisuke Urahara | 1891 A.D. - ? | Founder of the SRDI; exile |
+| Mayuri Kurotsuchi | current | Current captain |
 
 ## Pipeline Flow
 
 ```text
-Aizen -> Kaname + Gin (parallel) -> Kyoraku -> Gate
-                                                |
-Yoruichi (on Aizen completion, main only) <-----+
+Urahara -> Hikifune + Uhin (parallel) -> Hiyori -> Gate
+                                                    |
+Nemu (on Urahara completion, main only) <-----------+
 
-Mayuri (scheduled, independent) -> triggers Aizen if dotfiles changed
+Mayuri (scheduled, independent) -> triggers Urahara if dotfiles changed
 ```
 
 ## Triggers
 
-- **Aizen**: push/PR to main, scheduled at 00:10 / 08:10 / 16:10 UTC, manual dispatch
-- **Mayuri**: scheduled at 04:10 / 12:10 / 20:10 UTC (midpoint between Aizen runs), manual dispatch
-- **Yoruichi**: `workflow_run` after Aizen completes on main
+- **Urahara**: push/PR to main, scheduled at 00:10 / 08:10 / 16:10 UTC, manual dispatch
+- **Mayuri**: scheduled at 04:10 / 12:10 / 20:10 UTC (midpoint between Urahara runs), manual dispatch
+- **Nemu**: `workflow_run` after Urahara completes on main

--- a/.github/workflows/hikifune.yml
+++ b/.github/workflows/hikifune.yml
@@ -1,7 +1,7 @@
-# Kaname Tosen - Captain of the 9th Division, Buttercup (Oblivion)
+# Kirio Hikifune - 12th Division, Calendula (Despair in Your Heart)
 # Runs Python quality checks (ruff, black, isort) and pytest with coverage.
 
-name: "Kaname - CI"
+name: "Hikifune - CI"
 
 on:
   workflow_call:
@@ -57,7 +57,7 @@ jobs:
       - name: Test summary
         if: always()
         run: |
-          echo "## Kaname: CI Results" >> $GITHUB_STEP_SUMMARY
+          echo "## Hikifune: CI Results" >> $GITHUB_STEP_SUMMARY
           echo "- Ruff: passed" >> $GITHUB_STEP_SUMMARY
           echo "- Black: passed" >> $GITHUB_STEP_SUMMARY
           echo "- isort: passed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/hiyori.yml
+++ b/.github/workflows/hiyori.yml
@@ -1,7 +1,7 @@
-# Kyoraku - 1st Division, Chrysanthemums (Truth and Innocence) - Build, Sign & Release
+# Hiyori Sarugaki - 12th Division, Calendula (Despair in Your Heart) - Build, Sign & Release
 # Builds image, scans with Trivy, signs with cosign (OIDC keyless),
 # and cuts semver releases from conventional commits.
-name: "Kyoraku - Build & Release"
+name: "Hiyori - Build & Release"
 
 on:
   workflow_call:
@@ -101,7 +101,7 @@ jobs:
       - name: Build summary
         if: always()
         run: |
-          echo "## Kyoraku: Build Results" >> $GITHUB_STEP_SUMMARY
+          echo "## Hiyori: Build Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
@@ -238,7 +238,7 @@ jobs:
       - name: Release summary
         if: always()
         run: |
-          echo "## Kyoraku: Release Results" >> $GITHUB_STEP_SUMMARY
+          echo "## Hiyori: Release Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ steps.version.outputs.skip }}" == "true" ]]; then
             echo "No release needed (no conventional commits)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/mayuri.yml
+++ b/.github/workflows/mayuri.yml
@@ -1,21 +1,21 @@
 ---
 # Mayuri Kurotsuchi - 12th Division, Calendula (Despair in Your Heart) - R&D / Watcher
-# Polls borninthedark/dotfiles for new commits; triggers the Aizen pipeline
+# Polls borninthedark/dotfiles for new commits; triggers the Urahara pipeline
 # when changes are detected.
 #
-# Shinigami Pipeline:
-#   Aizen    -> Orchestrator (5th Division, Lily of the Valley -- Sacrifice)
-#   Kaname   -> CI: lint + test (9th Division, Buttercup -- Oblivion)
-#   Gin      -> Security scanning (3rd Division, Marigold -- Despair)
-#   Kyoraku  -> Build, scan, sign, release (1st Division, Chrysanthemums -- Truth and Innocence)
-#   Yoruichi -> Status report (2nd Division, Tulip -- Seek Nothing)
+# 12th Division Pipeline:
+#   Urahara  -> Orchestrator (12th Division, Calendula -- Despair in Your Heart)
+#   Hikifune -> CI: lint + test (12th Division, Calendula -- Despair in Your Heart)
+#   Uhin     -> Security scanning (12th Division, Calendula -- Despair in Your Heart)
+#   Hiyori   -> Build, scan, sign, release (12th Division, Calendula -- Despair in Your Heart)
+#   Nemu     -> Status report (12th Division, Calendula -- Despair in Your Heart)
 #   Mayuri   -> Dotfiles watcher / R&D trigger (12th Division, Calendula -- Despair in Your Heart)
 
 name: "Mayuri - Dotfiles Watcher"
 
 on:
   schedule:
-    - cron: "10 4,12,20 * * *"  # 04:10, 12:10, 20:10 UTC — midpoint between Aizen runs
+    - cron: "10 4,12,20 * * *"  # 04:10, 12:10, 20:10 UTC — midpoint between Urahara runs
   workflow_dispatch:
 
 permissions:
@@ -58,7 +58,7 @@ jobs:
             echo "No changes detected — skipping build."
           fi
 
-      - name: Trigger Aizen pipeline
+      - name: Trigger Urahara pipeline
         if: steps.compare.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,13 +67,13 @@ jobs:
             -X POST \
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/borninthedark/exousia/actions/workflows/aizen.yml/dispatches" \
+            "https://api.github.com/repos/borninthedark/exousia/actions/workflows/urahara.yml/dispatches" \
             -d '{"ref":"main"}')
           if [ "${HTTP_STATUS}" != "204" ]; then
             echo "ERROR: workflow dispatch returned HTTP ${HTTP_STATUS}" >&2
             exit 1
           fi
-          echo "Aizen pipeline triggered (dotfiles changed)."
+          echo "Urahara pipeline triggered (dotfiles changed)."
 
       - name: Update tracked SHA
         if: steps.compare.outputs.changed == 'true'

--- a/.github/workflows/nemu.yml
+++ b/.github/workflows/nemu.yml
@@ -1,20 +1,20 @@
 ---
-# Yoruichi Shihoin - 2nd Division, Tulip (Seek Nothing) - Goddess of Flash
-# Post-CI housekeeping: generates STATUS.md and updates README badges
-# after the Aizen pipeline completes on main.
+# Nemu Kurotsuchi - 12th Division, Calendula (Despair in Your Heart)
+# Post-CI housekeeping: generates STATUS.md after the Urahara pipeline
+# completes on main. README is managed by the generate-readme pre-commit hook.
 #
-# Shinigami Pipeline:
-#   Aizen     -> Orchestrator (5th Division, Lily of the Valley -- Sacrifice)
-#   Kaname    -> CI: lint + test (9th Division, Buttercup -- Oblivion)
-#   Gin       -> Security scanning (3rd Division, Marigold -- Despair)
-#   Kyoraku  -> Build, scan, sign, release (1st Division, Chrysanthemums -- Truth and Innocence)
-#   Yoruichi -> Status report (2nd Division, Tulip -- Seek Nothing)
+# 12th Division Pipeline:
+#   Urahara  -> Orchestrator (12th Division, Calendula -- Despair in Your Heart)
+#   Hikifune -> CI: lint + test (12th Division, Calendula -- Despair in Your Heart)
+#   Uhin     -> Security scanning (12th Division, Calendula -- Despair in Your Heart)
+#   Hiyori   -> Build, scan, sign, release (12th Division, Calendula -- Despair in Your Heart)
+#   Nemu     -> Status report (12th Division, Calendula -- Despair in Your Heart)
 
-name: "Yoruichi - Status Report"
+name: "Nemu - Status Report"
 
 on:
   workflow_run:
-    workflows: ["Aizen - Orchestrator"]
+    workflows: ["Urahara - Orchestrator"]
     types: [completed]
     branches: [main]
 
@@ -48,13 +48,13 @@ jobs:
               ][0].conclusion // "skipped"'
           }
 
-          KANAME=$(get_conclusion "Kaname")
-          GIN=$(get_conclusion "Gin")
-          KYORAKU=$(get_conclusion "Kyoraku")
+          HIKIFUNE=$(get_conclusion "Hikifune")
+          UHIN=$(get_conclusion "Uhin")
+          HIYORI=$(get_conclusion "Hiyori")
 
-          echo "kaname=${KANAME}" >> "$GITHUB_OUTPUT"
-          echo "gin=${GIN}" >> "$GITHUB_OUTPUT"
-          echo "kyoraku=${KYORAKU}" >> "$GITHUB_OUTPUT"
+          echo "hikifune=${HIKIFUNE}" >> "$GITHUB_OUTPUT"
+          echo "uhin=${UHIN}" >> "$GITHUB_OUTPUT"
+          echo "hiyori=${HIYORI}" >> "$GITHUB_OUTPUT"
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Extract build metadata
@@ -81,9 +81,9 @@ jobs:
         env:
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
-          KANAME: ${{ steps.jobs.outputs.kaname }}
-          GIN: ${{ steps.jobs.outputs.gin }}
-          KYORAKU: ${{ steps.jobs.outputs.kyoraku }}
+          HIKIFUNE: ${{ steps.jobs.outputs.hikifune }}
+          UHIN: ${{ steps.jobs.outputs.uhin }}
+          HIYORI: ${{ steps.jobs.outputs.hiyori }}
           IMAGE_TYPE: ${{ steps.meta.outputs.image_type }}
           IMAGE_VERSION: ${{ steps.meta.outputs.image_version }}
           WM: ${{ steps.meta.outputs.wm }}
@@ -97,13 +97,13 @@ jobs:
 
           > Last updated: ${TIMESTAMP} | [View Run](${RUN_URL})
 
-          ## Pipeline: Aizen
+          ## Pipeline: Urahara
 
           | Captain | Division | Role | Status |
           |---------|----------|------|--------|
-          | Kaname | 9th (Oblivion) | CI: lint + test | ${KANAME} |
-          | Gin | 3rd (Despair) | Security scanning | ${GIN} |
-          | Kyoraku | 1st (Truth and Innocence) | Build & Release | ${KYORAKU} |
+          | Hikifune | 12th (Despair in Your Heart) | CI: lint + test | ${HIKIFUNE} |
+          | Uhin | 12th (Despair in Your Heart) | Security scanning | ${UHIN} |
+          | Hiyori | 12th (Despair in Your Heart) | Build & Release | ${HIYORI} |
 
           **Result:** ${CONCLUSION}
 
@@ -120,23 +120,12 @@ jobs:
           EOF
           sed -i 's/^          //' STATUS.md
 
-      - name: Update README badge
-        env:
-          IMAGE_VERSION: ${{ steps.meta.outputs.image_version }}
-          WM: ${{ steps.meta.outputs.wm }}
-        run: |
-          WM_DISPLAY=$(echo "${WM}" | sed 's/./\U&/')
-          BADGE_TEXT="Fedora%20${IMAGE_VERSION}%20%2F%20${WM_DISPLAY}"
-          sed -i \
-            "s|\(Last%20Build-\)[^?]*\(-0A74DA\)|\1${BADGE_TEXT}\2|" \
-            README.md
-
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           BOT_EMAIL="41898282+github-actions[bot]"
           git config user.email "${BOT_EMAIL}@users.noreply.github.com"
-          git add STATUS.md README.md
+          git add STATUS.md
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/uhin.yml
+++ b/.github/workflows/uhin.yml
@@ -1,8 +1,8 @@
-# Gin Ichimaru - Captain of the 3rd Division, Marigold (Despair)
+# Uhin Zenjoji - 12th Division, Calendula (Despair in Your Heart)
 # Validates file structure, generates Containerfile, runs Hadolint + Checkov +
-# Trivy config scan + Bandit, then uploads the generated Containerfile for Kyoraku.
+# Trivy config scan + Bandit, then uploads the generated Containerfile for Hiyori.
 
-name: "Gin - Security"
+name: "Uhin - Security"
 
 on:
   workflow_call:
@@ -22,7 +22,7 @@ jobs:
 
       - name: Verify required file structure
         run: |
-          echo "## Gin: File Structure Check" >> $GITHUB_STEP_SUMMARY
+          echo "## Uhin: File Structure Check" >> $GITHUB_STEP_SUMMARY
 
           for file in sway.desktop environment start-sway; do
             if [[ ! -f "overlays/sway/session/$file" ]]; then
@@ -87,7 +87,7 @@ jobs:
       - name: Security summary
         if: always()
         run: |
-          echo "## Gin: Security Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "## Uhin: Security Scan Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Scanner | Target |" >> $GITHUB_STEP_SUMMARY
           echo "|---------|--------|" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/urahara.yml
+++ b/.github/workflows/urahara.yml
@@ -1,13 +1,13 @@
-# Aizen - 5th Division, Lily of the Valley (Sacrifice) - Orchestrator
-# Calls Kaname (CI) + Gin (security) in parallel, then Kyoraku, then gate.
+# Kisuke Urahara - 12th Division, Calendula (Despair in Your Heart) - Orchestrator
+# Calls Hikifune (CI) + Uhin (Security) in parallel, then Hiyori, then gate.
 #
-# Shinigami Pipeline:
-#   Aizen     -> Orchestrator (5th Division, Lily of the Valley -- Sacrifice)
-#   Kaname    -> CI: lint + test (9th Division, Buttercup -- Oblivion)
-#   Gin       -> Security scanning (3rd Division, Marigold -- Despair)
-#   Kyoraku  -> Build -> scan + sign -> release (1st Division, Chrysanthemums -- Truth and Innocence)
+# 12th Division Pipeline:
+#   Urahara  -> Orchestrator (12th Division, Calendula -- Despair in Your Heart)
+#   Hikifune -> CI: lint + test (12th Division, Calendula -- Despair in Your Heart)
+#   Uhin     -> Security scanning (12th Division, Calendula -- Despair in Your Heart)
+#   Hiyori   -> Build -> scan + sign -> release (12th Division, Calendula -- Despair in Your Heart)
 
-name: "Aizen - Orchestrator"
+name: "Urahara - Orchestrator"
 
 on:
   push:
@@ -51,25 +51,25 @@ permissions:
   id-token: write
 
 jobs:
-  # -- Kaname (CI) + Gin (Security) run in parallel --
-  kaname:
-    name: "Kaname (CI)"
-    uses: ./.github/workflows/kaname.yml
+  # -- Hikifune (CI) + Uhin (Security) run in parallel --
+  hikifune:
+    name: "Hikifune (CI)"
+    uses: ./.github/workflows/hikifune.yml
     secrets: inherit
     permissions:
       contents: read
 
-  gin:
-    name: "Gin (Security)"
-    uses: ./.github/workflows/gin.yml
+  uhin:
+    name: "Uhin (Security)"
+    uses: ./.github/workflows/uhin.yml
     permissions:
       contents: read
 
-  # -- Kyoraku (Build) runs after both pass --
-  kyoraku:
-    name: "Kyoraku (Build)"
-    needs: [kaname, gin]
-    uses: ./.github/workflows/kyoraku.yml
+  # -- Hiyori (Build) runs after both pass --
+  hiyori:
+    name: "Hiyori (Build)"
+    needs: [hikifune, uhin]
+    uses: ./.github/workflows/hiyori.yml
     with:
       image_type: ${{ inputs.image_type || 'fedora-sway-atomic' }}
       distro_version: ${{ inputs.distro_version || '43' }}
@@ -83,23 +83,23 @@ jobs:
   # -- Gate: summary of all jobs --
   gate:
     name: "Gate (Summary)"
-    needs: [kaname, gin, kyoraku]
+    needs: [hikifune, uhin, hiyori]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Pipeline summary
         run: |
-          echo "## Aizen Pipeline Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Urahara Pipeline Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Workflow | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Kaname (CI) | ${{ needs.kaname.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Gin (Security) | ${{ needs.gin.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Kyoraku (Build) | ${{ needs.kyoraku.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Hikifune (CI) | ${{ needs.hikifune.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Uhin (Security) | ${{ needs.uhin.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Hiyori (Build) | ${{ needs.hiyori.result }} |" >> $GITHUB_STEP_SUMMARY
 
       - name: Fail if any job failed
         if: >-
-          needs.kaname.result == 'failure' ||
-          needs.gin.result == 'failure' ||
-          needs.kyoraku.result == 'failure'
+          needs.hikifune.result == 'failure' ||
+          needs.uhin.result == 'failure' ||
+          needs.hiyori.result == 'failure'
         run: exit 1

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 > from *BLEACH*. All rights belong to Tite Kubo and
 > respective copyright holders.
 
-[![Reiatsu](https://img.shields.io/github/actions/workflow/status/borninthedark/exousia/aizen.yml?branch=main&style=for-the-badge&logo=zap&logoColor=white&label=Reiatsu&color=00A4EF)](https://github.com/borninthedark/exousia/actions/workflows/aizen.yml)
-[![Last Build: Fedora 43 / Sway](https://img.shields.io/badge/Last%20Build-Fedora%2043%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/borninthedark/exousia/actions/workflows/aizen.yml?query=branch%3Amain+is%3Asuccess)
+[![Reiatsu](https://img.shields.io/github/actions/workflow/status/borninthedark/exousia/urahara.yml?branch=main&style=for-the-badge&logo=zap&logoColor=white&label=Reiatsu&color=00A4EF)](https://github.com/borninthedark/exousia/actions/workflows/urahara.yml)
+[![Last Build: Fedora 43 / Sway](https://img.shields.io/badge/Last%20Build-Fedora%2043%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/borninthedark/exousia/actions/workflows/urahara.yml?query=branch%3Amain+is%3Asuccess)
 [![Highly Experimental](https://img.shields.io/badge/Highly%20Experimental-DANGER%21-E53935?style=for-the-badge&logo=skull&logoColor=white)](#highly-experimental-disclaimer)
 
 DevSecOps-hardened, container-based immutable operating systems built on
@@ -27,7 +27,7 @@ change requires 50% branch coverage to merge (ratcheting toward 75%).
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
   - [Build Flow](#build-flow)
-  - [The Shinigami Pipeline](#the-shinigami-pipeline)
+  - [The 12th Division Pipeline](#the-12th-division-pipeline)
   - [Versioning](#versioning)
 - [Customizing Builds](#customizing-builds)
 - [Local Build Pipeline](#local-build-pipeline)
@@ -73,7 +73,7 @@ make build
 curl -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $GITHUB_TOKEN" \
-  https://api.github.com/repos/borninthedark/exousia/actions/workflows/aizen.yml/dispatches \
+  https://api.github.com/repos/borninthedark/exousia/actions/workflows/urahara.yml/dispatches \
   -d '{"ref":"main","inputs":{"image_type":"fedora-bootc","distro_version":"43","enable_plymouth":"true"}}'
 ```
 
@@ -112,29 +112,29 @@ graph LR
 | **Overlays** | Static files, configs, and scripts under `overlays/base/` (shared) and `overlays/sway/` (desktop) |
 | **Tests** | Bats tests in `custom-tests/` validate the built image |
 
-### The Shinigami Pipeline
+### The 12th Division Pipeline
 
-Every CI workflow is named after a captain from the Gotei 13. Each captain's
-division maps to the workflow's role:
+Every CI workflow is named after a 12th Division captain or member (Shinigami Research
+and Development Institute). Division flower: Calendula — Despair in Your Heart.
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#1a1a2e', 'primaryTextColor': '#e0e0e0', 'primaryBorderColor': '#4fc3f7', 'lineColor': '#4fc3f7', 'secondaryColor': '#16213e', 'tertiaryColor': '#0f3460', 'edgeLabelBackground': '#1a1a2e'}}}%%
 graph TD
-    A["Aizen"] --> B["Kaname"] & C["Gin"]
-    B & C --> K["Kyoraku: build"]
+    A["Urahara"] --> B["Hikifune"] & C["Uhin"]
+    B & C --> K["Hiyori: build"]
     K --> S["scan"] & SG["sign"]
     S & SG --> R["release"]
     R --> G["Gate"]
-    G --> Y["Yoruichi"]
+    G --> Y["Nemu"]
 ```
 
 | Captain | Division | Role | Key Tools |
 |---------|----------|------|-----------|
-| **Aizen** | 5th (Sacrifice) | Orchestrator | Calls Kaname + Gin in parallel, then Kyoraku |
-| **Kaname** | 9th (Oblivion) | CI | Ruff, Black, isort, pytest |
-| **Gin** | 3rd (Despair) | Security | Hadolint, Checkov, Trivy config scan, Bandit |
-| **Kyoraku** | 1st (Truth and Innocence) | Build & Release | Docker Buildx, Cosign (OIDC), Trivy image scan, semver |
-| **Yoruichi** | 2nd (Seek Nothing) | Status Report | Generates STATUS.md, updates badges |
+| **Urahara** | 12th (Despair in Your Heart) | Orchestrator | Calls Hikifune + Uhin in parallel, then Hiyori |
+| **Hikifune** | 12th (Despair in Your Heart) | CI | Ruff, Black, isort, pytest |
+| **Uhin** | 12th (Despair in Your Heart) | Security | Hadolint, Checkov, Trivy config scan, Bandit |
+| **Hiyori** | 12th (Despair in Your Heart) | Build & Release | Docker Buildx, Cosign (OIDC), Trivy image scan, semver |
+| **Nemu** | 12th (Despair in Your Heart) | Status Report | Generates STATUS.md |
 
 ### Versioning
 
@@ -219,7 +219,7 @@ Configure in GitHub **Settings > Secrets and variables > Actions**.
 | `DOCKERHUB_USERNAME` | DockerHub username | Yes |
 | `REGISTRY_URL` | Registry URL (defaults to `docker.io`) | No |
 
-Secrets propagate to child workflows via `secrets: inherit` in Aizen.
+Secrets propagate to child workflows via `secrets: inherit` in Urahara.
 
 ## Documentation
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,13 +2,13 @@
 
 > Last updated: 2026-03-14 19:45:00 UTC | [View Run](https://github.com/borninthedark/exousia/actions/runs/23094980969)
 
-## Pipeline: Aizen
+## Pipeline: Urahara
 
 | Captain | Division | Role | Status |
 |---------|----------|------|--------|
-| Kaname | 9th (Oblivion) | CI: lint + test | success |
-| Gin | 3rd (Despair) | Security scanning | success |
-| Kyoraku | 1st (Truth and Innocence) | Build & Release | success |
+| Hikifune | 12th (Despair in Your Heart) | CI: lint + test | success |
+| Uhin | 12th (Despair in Your Heart) | Security scanning | success |
+| Hiyori | 12th (Despair in Your Heart) | Build & Release | success |
 
 **Result:** success
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,16 +18,16 @@ Comprehensive documentation for building, testing, and deploying custom Fedora b
 
 ## CI/CD Workflows
 
-Exousia uses a Shinigami-themed GitHub Actions pipeline (Gotei 13 captains):
+Exousia uses a 12th Division-themed GitHub Actions pipeline (Shinigami Research and Development Institute):
 
 | Workflow | File | Role |
 |----------|------|------|
-| **Aizen** | `aizen.yml` | 5th (Sacrifice) -- Orchestrator: calls Kaname + Gin in parallel, then Kyoraku, then gate |
-| **Kaname** | `kaname.yml` | 9th (Oblivion) -- CI: Ruff, Black, isort, pytest |
-| **Gin** | `gin.yml` | 3rd (Despair) -- Security: Hadolint, Checkov, Trivy config scan, Bandit |
-| **Kyoraku** | `kyoraku.yml` | 1st (Truth and Innocence) -- Buildah, Cosign, Trivy scan, semver release |
-| **Yoruichi** | `yoruichi.yml` | 2nd (Seek Nothing) -- Post-CI: STATUS.md, badge updates |
-| **Mayuri** | `mayuri.yml` | 12th (R&D) -- Dotfiles watcher: polls `borninthedark/dotfiles`, triggers Aizen on change |
+| **Urahara** | `urahara.yml` | 12th (Despair in Your Heart) -- Orchestrator: calls Hikifune + Uhin in parallel, then Hiyori, then gate |
+| **Hikifune** | `hikifune.yml` | 12th (Despair in Your Heart) -- CI: Ruff, Black, isort, pytest |
+| **Uhin** | `uhin.yml` | 12th (Despair in Your Heart) -- Security: Hadolint, Checkov, Trivy config scan, Bandit |
+| **Hiyori** | `hiyori.yml` | 12th (Despair in Your Heart) -- Build, Cosign, Trivy scan, semver release |
+| **Nemu** | `nemu.yml` | 12th (Despair in Your Heart) -- Post-CI: STATUS.md |
+| **Mayuri** | `mayuri.yml` | 12th (Despair in Your Heart) -- Dotfiles watcher: polls `borninthedark/dotfiles`, triggers Urahara on change |
 
 Version bumps are automatic via [conventional commits](https://www.conventionalcommits.org/):
 `feat:` minor, `fix:` patch, `feat!:` major.
@@ -51,7 +51,7 @@ Configure in GitHub repository settings under **Settings > Secrets and variables
 | `DOCKERHUB_USERNAME` | DockerHub username | Yes |
 | `REGISTRY_URL` | Registry URL (defaults to `docker.io`) | No |
 
-Secrets are passed to reusable workflows via `secrets: inherit` in Aizen.
+Secrets are passed to reusable workflows via `secrets: inherit` in Urahara.
 
 ---
 

--- a/docs/chezmoi-integration.md
+++ b/docs/chezmoi-integration.md
@@ -475,10 +475,10 @@ dotfiles/
 
 The **Mayuri** workflow (`.github/workflows/mayuri.yml`) automatically triggers a new image build when the dotfiles repository changes:
 
-1. Runs at 04:10, 12:10, and 20:10 UTC — midway between scheduled Aizen builds
+1. Runs at 04:10, 12:10, and 20:10 UTC — midway between scheduled Urahara builds
 2. Fetches the latest commit SHA from `borninthedark/dotfiles` via the GitHub API
 3. Compares it against the last-seen SHA stored in `.dotfiles-sha`
-4. If they differ: triggers the Aizen pipeline via `workflow_dispatch` and commits the new SHA
+4. If they differ: triggers the Urahara pipeline via `workflow_dispatch` and commits the new SHA
 
 This means a push to the dotfiles repository will result in a rebuilt image within ~4 hours.
 

--- a/tools/generate-readme.py
+++ b/tools/generate-readme.py
@@ -110,8 +110,8 @@ def generate_readme(root: Path) -> str:
 > from *BLEACH*. All rights belong to Tite Kubo and
 > respective copyright holders.
 
-[![Reiatsu](https://img.shields.io/github/actions/workflow/status/{REPO}/aizen.yml?branch=main&style=for-the-badge&logo=zap&logoColor=white&label=Reiatsu&color=00A4EF)](https://github.com/{REPO}/actions/workflows/aizen.yml)
-[![Last Build: Fedora 43 / Sway](https://img.shields.io/badge/Last%20Build-Fedora%2043%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/{REPO}/actions/workflows/aizen.yml?query=branch%3Amain+is%3Asuccess)
+[![Reiatsu](https://img.shields.io/github/actions/workflow/status/{REPO}/urahara.yml?branch=main&style=for-the-badge&logo=zap&logoColor=white&label=Reiatsu&color=00A4EF)](https://github.com/{REPO}/actions/workflows/urahara.yml)
+[![Last Build: Fedora 43 / Sway](https://img.shields.io/badge/Last%20Build-Fedora%2043%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/{REPO}/actions/workflows/urahara.yml?query=branch%3Amain+is%3Asuccess)
 [![Highly Experimental](https://img.shields.io/badge/Highly%20Experimental-DANGER%21-E53935?style=for-the-badge&logo=skull&logoColor=white)](#highly-experimental-disclaimer)
 
 DevSecOps-hardened, container-based immutable operating systems built on
@@ -130,7 +130,7 @@ change requires 50% branch coverage to merge (ratcheting toward 75%).
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
   - [Build Flow](#build-flow)
-  - [The Shinigami Pipeline](#the-shinigami-pipeline)
+  - [The 12th Division Pipeline](#the-12th-division-pipeline)
   - [Versioning](#versioning)
 - [Customizing Builds](#customizing-builds)
 - [Local Build Pipeline](#local-build-pipeline)
@@ -176,7 +176,7 @@ make build
 curl -X POST \\
   -H "Accept: application/vnd.github+json" \\
   -H "Authorization: Bearer $GITHUB_TOKEN" \\
-  https://api.github.com/repos/{REPO}/actions/workflows/aizen.yml/dispatches \\
+  https://api.github.com/repos/{REPO}/actions/workflows/urahara.yml/dispatches \\
   -d '{{"ref":"main","inputs":{{"image_type":"fedora-bootc","distro_version":"43","enable_plymouth":"true"}}}}'
 ```
 
@@ -215,29 +215,29 @@ graph LR
 | **Overlays** | Static files, configs, and scripts under `overlays/base/` (shared) and `overlays/sway/` (desktop) |
 | **Tests** | Bats tests in `custom-tests/` validate the built image |
 
-### The Shinigami Pipeline
+### The 12th Division Pipeline
 
-Every CI workflow is named after a captain from the Gotei 13. Each captain's
-division maps to the workflow's role:
+Every CI workflow is named after a 12th Division captain or member (Shinigami Research
+and Development Institute). Division flower: Calendula — Despair in Your Heart.
 
 ```mermaid
 %%{{init: {{'theme': 'base', 'themeVariables': {{'primaryColor': '#1a1a2e', 'primaryTextColor': '#e0e0e0', 'primaryBorderColor': '#4fc3f7', 'lineColor': '#4fc3f7', 'secondaryColor': '#16213e', 'tertiaryColor': '#0f3460', 'edgeLabelBackground': '#1a1a2e'}}}}}}%%
 graph TD
-    A["Aizen"] --> B["Kaname"] & C["Gin"]
-    B & C --> K["Kyoraku: build"]
+    A["Urahara"] --> B["Hikifune"] & C["Uhin"]
+    B & C --> K["Hiyori: build"]
     K --> S["scan"] & SG["sign"]
     S & SG --> R["release"]
     R --> G["Gate"]
-    G --> Y["Yoruichi"]
+    G --> Y["Nemu"]
 ```
 
 | Captain | Division | Role | Key Tools |
 |---------|----------|------|-----------|
-| **Aizen** | 5th (Sacrifice) | Orchestrator | Calls Kaname + Gin in parallel, then Kyoraku |
-| **Kaname** | 9th (Oblivion) | CI | Ruff, Black, isort, pytest |
-| **Gin** | 3rd (Despair) | Security | Hadolint, Checkov, Trivy config scan, Bandit |
-| **Kyoraku** | 1st (Truth and Innocence) | Build & Release | Docker Buildx, Cosign (OIDC), Trivy image scan, semver |
-| **Yoruichi** | 2nd (Seek Nothing) | Status Report | Generates STATUS.md, updates badges |
+| **Urahara** | 12th (Despair in Your Heart) | Orchestrator | Calls Hikifune + Uhin in parallel, then Hiyori |
+| **Hikifune** | 12th (Despair in Your Heart) | CI | Ruff, Black, isort, pytest |
+| **Uhin** | 12th (Despair in Your Heart) | Security | Hadolint, Checkov, Trivy config scan, Bandit |
+| **Hiyori** | 12th (Despair in Your Heart) | Build & Release | Docker Buildx, Cosign (OIDC), Trivy image scan, semver |
+| **Nemu** | 12th (Despair in Your Heart) | Status Report | Generates STATUS.md |
 
 ### Versioning
 
@@ -322,7 +322,7 @@ Configure in GitHub **Settings > Secrets and variables > Actions**.
 | `DOCKERHUB_USERNAME` | DockerHub username | Yes |
 | `REGISTRY_URL` | Registry URL (defaults to `docker.io`) | No |
 
-Secrets propagate to child workflows via `secrets: inherit` in Aizen.
+Secrets propagate to child workflows via `secrets: inherit` in Urahara.
 
 ## Documentation
 


### PR DESCRIPTION
  All workflow files, docs, and references updated:
    aizen    → urahara   (orchestrator)
    kaname   → hikifune  (CI)
    gin      → uhin      (security)
    kyoraku  → hiyori    (build & release)
    yoruichi → nemu      (status report)

  Mayuri remains; now triggers urahara instead of aizen.
  README, STATUS.md, docs/README.md, and chezmoi-integration.md
  updated to reflect 12th Division theming throughout.