### PR TITLE
feat: add pentest bundle, GHCR auth, localhost-only Quadlets, and CVE docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,20 @@ and GitHub Actions pushes signed images to DockerHub.
 Development follows a **TDD-first, shift-left** methodology — see
 [Contributing](#contributing) for details.
 
+## CVE Remediations
+
+Exousia ships patched versions of packages ahead of upstream Fedora when
+required. Packages are built from upstream source, hosted as OCI images on
+GHCR, and injected at build time via RPM overrides. See
+[SECURITY.md](SECURITY.md#rpm-override-process) for the full process.
+
+| Package | Patched Version | Reason |
+|---------|----------------|--------|
+| flatpak | 1.16.6 | CVE remediation — fixes disclosed 2026-04-12 ([release notes](https://github.com/flatpak/flatpak/releases/tag/1.16.6)) |
+
 ## Table of Contents
 
+- [CVE Remediations](#cve-remediations)
 - [Highly Experimental Disclaimer](#highly-experimental-disclaimer)
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
@@ -149,6 +161,7 @@ Versions are automatic via [conventional commits](https://www.conventionalcommit
 
 | Scope | Location |
 |-------|----------|
+| RPM overrides | `overlays/base/packages/common/rpm-overrides.yml` |
 | Common package sets | `overlays/base/packages/common/base-*.yml` |
 | Feature package sets | `overlays/base/packages/common/*.yml` |
 | Window-manager package sets | `overlays/base/packages/window-managers/*.yml` |
@@ -227,6 +240,7 @@ Configure in GitHub **Settings > Secrets and variables > Actions**.
 | Name | Purpose |
 |------|---------|
 | `DOCKERHUB_TOKEN` | DockerHub access token |
+| `GHCR_PAT` | GHCR personal access token (`packages:read`) |
 
 **Variables:**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,113 @@ Exousia employs a defense-in-depth approach:
 |---------|----------------|--------|-------------|
 | flatpak | >= 1.16.6 | CVE remediation ([release notes](https://github.com/flatpak/flatpak/releases/tag/1.16.6)) | 2026-04-12 |
 
+## RPM Override Process
+
+When Fedora has not yet shipped a patched version of a package, Exousia can
+build the fix from upstream source and inject it into the image at build time.
+This is how the flatpak CVE (disclosed 2026-04-12) was remediated before
+Fedora shipped `>= 1.16.6`.
+
+### 1. Build the RPM from upstream source
+
+Use a Fedora toolbox to isolate the build environment:
+
+```bash
+toolbox enter
+
+# Install build dependencies
+sudo dnf builddep flatpak
+sudo dnf install rpmdevtools rpm-build
+
+# Set up the RPM build tree
+rpmdev-setuptree
+
+# Download the Fedora SRPM as the base spec
+dnf download --source flatpak
+rpm -ivh flatpak-*.src.rpm
+
+# Replace the upstream tarball with the patched release
+cd ~/rpmbuild/SOURCES
+curl -LO https://github.com/flatpak/flatpak/releases/download/1.16.6/flatpak-1.16.6.tar.xz
+
+# Patch the spec: bump Version, update changelog
+cd ~/rpmbuild/SPECS
+# Edit flatpak.spec — set Version: 1.16.6 and add a %changelog entry
+
+# Build (disable debuginfo if not needed)
+rpmbuild -bb --define "debug_package %{nil}" flatpak.spec
+```
+
+The output RPMs land in `~/rpmbuild/RPMS/x86_64/`.
+
+### 2. Host the RPMs on GHCR as a scratch OCI image
+
+Package the RPMs into a minimal OCI image so the Containerfile can
+`COPY --from` them:
+
+```bash
+# Create a staging directory
+mkdir -p /tmp/flatpak-rpms && cp ~/rpmbuild/RPMS/x86_64/flatpak-*.rpm /tmp/flatpak-rpms/
+
+# Build and push a scratch image containing only the RPMs
+cat <<'DOCKERFILE' > /tmp/flatpak-rpms/Containerfile
+FROM scratch
+COPY *.rpm /rpms/
+DOCKERFILE
+
+podman build -t ghcr.io/borninthedark/flatpak-rpms:1.16.6 /tmp/flatpak-rpms/
+podman login ghcr.io
+podman push ghcr.io/borninthedark/flatpak-rpms:1.16.6
+```
+
+### 3. Register the override in the package spec
+
+Add an entry to `overlays/base/packages/common/rpm-overrides.yml`:
+
+```yaml
+spec:
+  overrides:
+    - package: flatpak
+      version: ">= 1.16.6"
+      image: ghcr.io/borninthedark/flatpak-rpms:1.16.6
+      reason: CVE remediation (disclosed 2026-04-12)
+      replaces:
+        - flatpak
+        - flatpak-libs
+        - flatpak-session-helper
+        - flatpak-selinux
+```
+
+The `replaces` list names every sub-package the RPM build produces. The
+transpiler (`yaml-to-containerfile.py`) reads this spec via
+`PackageLoader.load_rpm_overrides()` and generates:
+
+1. `COPY --from=ghcr.io/borninthedark/flatpak-rpms:1.16.6 /rpms/ /tmp/rpm-override-0/`
+2. `RUN dnf install -y /tmp/rpm-override-0/*.rpm`
+
+These stages run after the main `dnf install`, overriding the repo version.
+
+### 4. Ensure CI can pull from GHCR
+
+The build workflow (`hiyori.yml`) authenticates with GHCR before the image
+build step so that `COPY --from` can pull the override image:
+
+```yaml
+- name: Login to GHCR (pull RPM overrides)
+  uses: docker/login-action@v4
+  with:
+    registry: ghcr.io
+    username: ${{ github.actor }}
+    password: ${{ secrets.GHCR_PAT }}
+```
+
+### 5. Remove the override when Fedora catches up
+
+Once Fedora ships a version that satisfies the minimum version constraint,
+remove the entry from `rpm-overrides.yml` and the corresponding row from the
+Active Remediations table above. The image on GHCR can be deleted or left
+as an archive.
+
 ## Dependency Management
 
 Dependencies are managed via:

--- a/adnyeus.yml
+++ b/adnyeus.yml
@@ -151,6 +151,7 @@ modules:
       - base-virtualization
       - base-security
       - base-network
+      - base-pentest
       - base-shell
     feature_bundles:
       - audio-production  # Fedora Jam audio suite: DAWs, plugins, PipeWire-JACK, RT tuning

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -101,9 +101,9 @@ Deploys Podman Quadlet services for local development:
 
 | Service | Port | Purpose |
 |---------|------|---------|
-| Forgejo | 3000 (HTTP), 2222 (SSH) | Self-hosted git forge |
+| Forgejo | 127.0.0.1:3000 (HTTP), 127.0.0.1:2222 (SSH) | Self-hosted git forge |
 | Forgejo Runner | -- | CI runner for Forgejo Actions |
-| Registry | 5000 | Local container registry |
+| Registry | 127.0.0.1:5000 | Local container registry |
 
 All services use the `exousia.network` (10.89.1.0/24) for inter-service communication.
 See [Local Build Pipeline](local-build-pipeline.md) for Quadlet setup, build
@@ -180,7 +180,7 @@ make ansible-apply           # Apply changes
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `firewall_open_ports` | `[22, 80, 443]` | Ports to open transiently |
+| `firewall_open_ports` | `[22]` | Ports to open transiently (SSH only; dev services bind to localhost) |
 | `network_dns_servers` | `[1.1.1.1, 9.9.9.9]` | DNS servers |
 | `services_runtime_overrides` | `[]` | systemd unit override list |
 | `user_config_scripts` | `[]` | Scripts to deploy to /tmp |

--- a/overlays/base/packages/common/base-pentest.yml
+++ b/overlays/base/packages/common/base-pentest.yml
@@ -1,0 +1,54 @@
+apiVersion: exousia.packages/v1alpha1
+kind: PackageBundle
+
+metadata:
+  name: base-pentest
+  type: common
+  description: >
+    Offensive security, penetration testing, and reconnaissance tools.
+    Fedora-repo equivalents of common Kali Linux tooling.
+
+spec:
+  source: rpm
+  stage: build
+  packages:
+    # -- Scanning & Enumeration --
+    - nmap
+    - masscan
+    - arp-scan
+    - fping
+    - hping3
+    - nuclei
+    - subfinder
+    - gobuster
+    - ffuf
+    - whatweb
+    - sslscan
+    - testssl
+    # -- Sniffing & MITM --
+    - wireshark-cli
+    - tcpdump
+    - ettercap
+    # -- Credential Testing --
+    - hydra
+    - john
+    - hashcat
+    - ncrack
+    - medusa
+    # -- Exploitation Frameworks --
+    - python3-impacket
+    - sqlmap
+    # -- Network Utilities --
+    - netcat
+    - socat
+    - proxychains-ng
+    - tor
+    - torsocks
+    - whois
+    - bind-utils
+    - traceroute
+  conflicts:
+    packages: []
+    features: []
+  requires:
+    features: []

--- a/overlays/deploy/exousia-registry.container
+++ b/overlays/deploy/exousia-registry.container
@@ -5,7 +5,7 @@ After=network-online.target
 [Container]
 Image=docker.io/library/registry:2
 ContainerName=exousia-registry
-PublishPort=5000:5000
+PublishPort=127.0.0.1:5000:5000
 Volume=exousia-registry-data.volume:/var/lib/registry
 Network=exousia.network
 Label=io.containers.autoupdate=registry

--- a/overlays/deploy/forgejo.container
+++ b/overlays/deploy/forgejo.container
@@ -5,8 +5,8 @@ After=network-online.target
 [Container]
 Image=codeberg.org/forgejo/forgejo:14.0.2
 ContainerName=forgejo
-PublishPort=3000:3000
-PublishPort=2222:2222
+PublishPort=127.0.0.1:3000:3000
+PublishPort=127.0.0.1:2222:2222
 Volume=forgejo-data.volume:/data
 Network=exousia.network
 Label=io.containers.autoupdate=registry

--- a/tools/generate-readme.py
+++ b/tools/generate-readme.py
@@ -127,8 +127,20 @@ and GitHub Actions pushes signed images to DockerHub.
 Development follows a **TDD-first, shift-left** methodology — see
 [Contributing](#contributing) for details.
 
+## CVE Remediations
+
+Exousia ships patched versions of packages ahead of upstream Fedora when
+required. Packages are built from upstream source, hosted as OCI images on
+GHCR, and injected at build time via RPM overrides. See
+[SECURITY.md](SECURITY.md#rpm-override-process) for the full process.
+
+| Package | Patched Version | Reason |
+|---------|----------------|--------|
+| flatpak | 1.16.6 | CVE remediation — fixes disclosed 2026-04-12 ([release notes](https://github.com/flatpak/flatpak/releases/tag/1.16.6)) |
+
 ## Table of Contents
 
+- [CVE Remediations](#cve-remediations)
 - [Highly Experimental Disclaimer](#highly-experimental-disclaimer)
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
@@ -257,6 +269,7 @@ Versions are automatic via [conventional commits](https://www.conventionalcommit
 
 | Scope | Location |
 |-------|----------|
+| RPM overrides | `overlays/base/packages/common/rpm-overrides.yml` |
 | Common package sets | `overlays/base/packages/common/base-*.yml` |
 | Feature package sets | `overlays/base/packages/common/*.yml` |
 | Window-manager package sets | `overlays/base/packages/window-managers/*.yml` |
@@ -335,6 +348,7 @@ Configure in GitHub **Settings > Secrets and variables > Actions**.
 | Name | Purpose |
 |------|---------|
 | `DOCKERHUB_TOKEN` | DockerHub access token |
+| `GHCR_PAT` | GHCR personal access token (`packages:read`) |
 
 **Variables:**
 


### PR DESCRIPTION
    Added base-pentest package bundle with Fedora-repo offensive security tools
   (nmap, wireshark-cli, hydra, hashcat, nuclei, impacket, etc.). Bind Forgejo
   and registry Quadlet ports to 127.0.0.1 and reduce firewall defaults to
   SSH-only. Add GHCR login step to Hiyori build workflow for RPM override
   pulls. Document the flatpak 1.16.6 CVE remediation process in SECURITY.md
   and surface the patched version in README + generate-readme template.