### PR TITLE
feat: parameterize Fedora version, add flatpak timers, update docs 

### DIFF
--- a/.github/actions/transpile/action.yml
+++ b/.github/actions/transpile/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: 'Image type (fedora-bootc, fedora-sway-atomic)'
     default: 'fedora-sway-atomic'
   distro_version:
-    description: 'Fedora version'
-    default: '43'
+    description: 'Fedora version (defaults to image-version from adnyeus.yml)'
+    default: ''
   enable_plymouth:
     description: 'Enable Plymouth boot splash'
     default: 'true'

--- a/.github/workflows/hiyori.yml
+++ b/.github/workflows/hiyori.yml
@@ -11,9 +11,9 @@ on:
         type: string
         default: "fedora-sway-atomic"
       distro_version:
-        description: "Fedora version"
+        description: "Fedora version (passed from Urahara, sourced from blueprint)"
         type: string
-        default: "43"
+        required: true
       enable_plymouth:
         description: "Enable Plymouth boot splash"
         type: boolean

--- a/.github/workflows/urahara.yml
+++ b/.github/workflows/urahara.yml
@@ -51,6 +51,24 @@ permissions:
   id-token: write
 
 jobs:
+  # -- Read default version from blueprint so we don't hardcode it --
+  defaults:
+    name: "Resolve Defaults"
+    runs-on: ubuntu-latest
+    outputs:
+      distro_version: ${{ steps.read.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: adnyeus.yml
+          sparse-checkout-cone-mode: false
+      - name: Read image-version from blueprint
+        id: read
+        run: |
+          VERSION=$(grep '^image-version:' adnyeus.yml | awk '{print $2}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Blueprint default version: ${VERSION}"
+
   # -- Hikifune (CI) + Uhin (Security) run in parallel --
   hikifune:
     name: "Hikifune (CI)"
@@ -68,11 +86,11 @@ jobs:
   # -- Hiyori (Build) runs after both pass --
   hiyori:
     name: "Hiyori (Build)"
-    needs: [hikifune, uhin]
+    needs: [defaults, hikifune, uhin]
     uses: ./.github/workflows/hiyori.yml
     with:
       image_type: ${{ inputs.image_type || 'fedora-sway-atomic' }}
-      distro_version: ${{ inputs.distro_version || '43' }}
+      distro_version: ${{ inputs.distro_version || needs.defaults.outputs.distro_version }}
       enable_plymouth: ${{ inputs.enable_plymouth == '' && true || inputs.enable_plymouth }}
     secrets: inherit
     permissions:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > respective copyright holders.
 
 [![Reiatsu](https://img.shields.io/github/actions/workflow/status/borninthedark/exousia/urahara.yml?branch=main&style=for-the-badge&logo=zap&logoColor=white&label=Reiatsu&color=00A4EF)](https://github.com/borninthedark/exousia/actions/workflows/urahara.yml)
-[![Last Build: Fedora / Sway](https://img.shields.io/badge/Last%20Build-Fedora%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/borninthedark/exousia/actions/workflows/urahara.yml?query=branch%3Amain+is%3Asuccess)
+[![Last Build: Fedora 43 / Sway](https://img.shields.io/badge/Last%20Build-Fedora%2043%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/borninthedark/exousia/actions/workflows/urahara.yml?query=branch%3Amain+is%3Asuccess)
 [![Highly Experimental](https://img.shields.io/badge/Highly%20Experimental-DANGER%21-E53935?style=for-the-badge&logo=skull&logoColor=white)](#highly-experimental-disclaimer)
 
 DevSecOps-hardened, container-based immutable operating systems built on
@@ -87,7 +87,7 @@ curl -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $GITHUB_TOKEN" \
   https://api.github.com/repos/borninthedark/exousia/actions/workflows/urahara.yml/dispatches \
-  -d '{"ref":"main","inputs":{"image_type":"fedora-bootc","distro_version":"44","enable_plymouth":"true"}}'
+  -d '{"ref":"main","inputs":{"image_type":"fedora-bootc","distro_version":"43","enable_plymouth":"true"}}'
 ```
 
 Or use the manual **workflow_dispatch** in the [GitHub Actions UI](https://github.com/borninthedark/exousia/actions).

--- a/adnyeus.yml
+++ b/adnyeus.yml
@@ -7,7 +7,7 @@ description: DevSecOps-hardened Fedora bootc image with Sway desktop
 image-version: 43
 
 # Base image configuration - can be overridden via build args
-base-image: quay.io/fedora/fedora-sway-atomic:43
+base-image: quay.io/fedora/fedora-sway-atomic
 image-type: fedora-bootc  # or fedora-bootc
 
 # Desktop environment selection

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -198,7 +198,7 @@ make ansible-apply           # Apply changes
 |----------|---------|-------------|
 | `ci_build_yaml_config` | `adnyeus.yml` | YAML blueprint to build |
 | `ci_build_image_type` | `fedora-sway-atomic` | Image type |
-| `ci_build_distro_version` | `43` | Fedora version |
+| `ci_build_distro_version` | from `adnyeus.yml` | Fedora version (reads `image-version` from blueprint) |
 | `ci_build_enable_plymouth` | `true` | Plymouth boot splash |
 | `ci_build_registry` | `docker.io` | Target registry |
 | `ci_build_image` | `1borninthedark/exousia` | Image path |

--- a/docs/distros.md
+++ b/docs/distros.md
@@ -21,7 +21,7 @@ Exousia focuses exclusively on Fedora bootc images with Sway as the window manag
 
 Images are tagged with:
 
-- OS family and version (e.g., `fedora-43`)
+- OS family and version (e.g., `fedora-{VERSION}`)
 - Image type (e.g., `fedora-sway-atomic`)
 - Git commit SHA
 - Branch name
@@ -34,17 +34,18 @@ Example: build a Fedora Sway Atomic image locally
 uv run python tools/yaml-to-containerfile.py \
   --config yaml-definitions/sway-atomic.yml \
   --image-type fedora-sway-atomic \
-  --fedora-version 44 \
+  --config adnyeus.yml \
   --output Containerfile.sway
 
-buildah build -f Containerfile.sway -t localhost/fedora-sway-atomic:44 .
+buildah build -f Containerfile.sway -t localhost/fedora-sway-atomic .
+
 ```
 
 ### Image Tags
 
 Built images use the following patterns:
 
-- **OS-Version**: `fedora-{version}` (e.g., `fedora-44`)
+- **OS-Version**: `fedora-{version}` (version from `adnyeus.yml`)
 - **Image Type**: `{image-type}` (e.g., `fedora-sway-atomic`)
 - **Main**: `main` (for main branch builds)
 - **SHA**: `sha-{git-commit-sha}`
@@ -60,7 +61,7 @@ Create a new YAML file for your custom Fedora image:
 name: my-custom-fedora
 description: Custom Fedora bootc image
 image-type: fedora-bootc
-base-image: quay.io/fedora/fedora-bootc:44
+base-image: quay.io/fedora/fedora-bootc
 
 labels:
   org.opencontainers.image.title: "My Custom Fedora"

--- a/docs/kernel-options.md
+++ b/docs/kernel-options.md
@@ -13,7 +13,7 @@ This document explains how to run different kernel versions on your Exousia boot
 
 ### Previous Default (Fedora Stable)
 
-- **fedora-bootc:43** → Fedora 43 stable kernel (~6.11.x)
+- **fedora-bootc:{VERSION}** → Fedora stable kernel
 - Most tested and stable, but older
 - Use if your CPU doesn't support x86-64-v3
 
@@ -153,7 +153,7 @@ Fedora's development kernel with debug options.
 
 - Slower performance (debug enabled)
 - Extreme instability
-- May not match Fedora 43 userspace
+- May not match Fedora stable userspace
 
 ## Recommended Approach
 

--- a/docs/reference/plymouth-usage.md
+++ b/docs/reference/plymouth-usage.md
@@ -70,7 +70,7 @@ podman build \
 1. Go to **Actions** → **Fedora Bootc DevSec CI**
 2. Click **Run workflow**
 3. Select options:
-   - **Fedora Version**: 42, 43, etc.
+   - **Fedora Version**: as defined in `adnyeus.yml` `image-version`
    - **Image Type**: fedora-bootc or fedora-sway-atomic
    - **Enable Plymouth**: ✓ (checked) or ☐ (unchecked)
 4. Click **Run workflow**

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -122,7 +122,7 @@ ENV BUILD_IMAGE_TYPE=${IMAGE_TYPE}
 
 ```bash
 podman build \
-  --build-arg FEDORA_VERSION=43 \
+  --build-arg FEDORA_VERSION="${VERSION}" \
   --build-arg IMAGE_TYPE=fedora-sway-atomic \
   -t localhost:5000/exousia:test .
 ```
@@ -337,7 +337,7 @@ cat overlays/sway/repos/*.repo
 
 ```bash
 # Some packages may not be available in all versions
-dnf search package-name --releasever=43
+dnf search package-name --releasever="${VERSION}"
 ```
 
 1. Check for typos in package name
@@ -626,7 +626,7 @@ git diff HEAD~1 custom-tests/
 
 ```bash
 # Reset to known-good configuration
-make switch-version VERSION=43 TYPE=fedora-sway-atomic
+make switch-version VERSION="${VERSION}" TYPE=fedora-sway-atomic
 
 # Clean build
 make clean

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -324,7 +324,7 @@ buildah unshare -- bats -r tests/ --verbose-run
 
 ```bash
 # Switch to fedora-bootc
-make switch-version VERSION=43 TYPE=fedora-bootc
+make switch-version VERSION="${VERSION}" TYPE=fedora-bootc
 
 # Build and test
 make build test
@@ -334,7 +334,7 @@ make build test
 
 ```bash
 # Switch to fedora-sway-atomic
-make switch-version VERSION=43 TYPE=fedora-sway-atomic
+make switch-version VERSION="${VERSION}" TYPE=fedora-sway-atomic
 
 # Build and test
 make build test

--- a/tools/generate-readme.py
+++ b/tools/generate-readme.py
@@ -5,7 +5,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 REPO = "borninthedark/exousia"
+_BLUEPRINT = Path(__file__).resolve().parent.parent / "adnyeus.yml"
+
+
+def _blueprint_version() -> str:
+    """Read image-version from the blueprint."""
+    if _BLUEPRINT.exists():
+        config = yaml.safe_load(_BLUEPRINT.read_text()) or {}
+        version = config.get("image-version")
+        if version:
+            return str(version)
+    return "43"
+
+
+FEDORA_VERSION = _blueprint_version()
 
 # Documentation entries: (rel_path, title, description)
 DOC_ENTRIES: list[tuple[str, str, str]] = [
@@ -116,7 +132,7 @@ def generate_readme(root: Path) -> str:
 > respective copyright holders.
 
 [![Reiatsu](https://img.shields.io/github/actions/workflow/status/{REPO}/urahara.yml?branch=main&style=for-the-badge&logo=zap&logoColor=white&label=Reiatsu&color=00A4EF)](https://github.com/{REPO}/actions/workflows/urahara.yml)
-[![Last Build: Fedora / Sway](https://img.shields.io/badge/Last%20Build-Fedora%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/{REPO}/actions/workflows/urahara.yml?query=branch%3Amain+is%3Asuccess)
+[![Last Build: Fedora {FEDORA_VERSION} / Sway](https://img.shields.io/badge/Last%20Build-Fedora%20{FEDORA_VERSION}%20%2F%20Sway-0A74DA?style=for-the-badge&logo=fedora&logoColor=white)](https://github.com/{REPO}/actions/workflows/urahara.yml?query=branch%3Amain+is%3Asuccess)
 [![Highly Experimental](https://img.shields.io/badge/Highly%20Experimental-DANGER%21-E53935?style=for-the-badge&logo=skull&logoColor=white)](#highly-experimental-disclaimer)
 
 DevSecOps-hardened, container-based immutable operating systems built on
@@ -195,7 +211,7 @@ curl -X POST \\
   -H "Accept: application/vnd.github+json" \\
   -H "Authorization: Bearer $GITHUB_TOKEN" \\
   https://api.github.com/repos/{REPO}/actions/workflows/urahara.yml/dispatches \\
-  -d '{{"ref":"main","inputs":{{"image_type":"fedora-bootc","distro_version":"44","enable_plymouth":"true"}}}}'
+  -d '{{"ref":"main","inputs":{{"image_type":"fedora-bootc","distro_version":"{FEDORA_VERSION}","enable_plymouth":"true"}}}}'
 ```
 
 Or use the manual **workflow_dispatch** in the [GitHub Actions UI](https://github.com/{REPO}/actions).

--- a/tools/resolve_build_config.py
+++ b/tools/resolve_build_config.py
@@ -19,8 +19,21 @@ except Exception as exc:
     YAML_SELECTOR_IMPORT_ERROR = exc
 
 
-DEFAULT_VERSION = "43"
 DEFAULT_IMAGE_TYPE = "fedora-sway-atomic"
+_BLUEPRINT = Path(__file__).resolve().parent.parent / "adnyeus.yml"
+
+
+def _read_blueprint_version() -> str:
+    """Read image-version from the blueprint as the single source of truth."""
+    if _BLUEPRINT.exists():
+        config = yaml.safe_load(_BLUEPRINT.read_text()) or {}
+        version = config.get("image-version")
+        if version:
+            return str(version)
+    return "43"  # absolute last-resort fallback
+
+
+DEFAULT_VERSION = _read_blueprint_version()
 
 
 def resolve_yaml_config(
@@ -216,7 +229,7 @@ def main() -> None:
     print("::group::Configuration Detection")
 
     input_image_type = os.environ.get("INPUT_IMAGE_TYPE", DEFAULT_IMAGE_TYPE)
-    input_distro_version = os.environ.get("INPUT_DISTRO_VERSION", DEFAULT_VERSION)
+    input_distro_version = os.environ.get("INPUT_DISTRO_VERSION", "") or DEFAULT_VERSION
     input_enable_plymouth = os.environ.get("INPUT_ENABLE_PLYMOUTH", "true").lower()
     input_enable_zfs = os.environ.get("INPUT_ENABLE_ZFS", "false").lower()
     input_window_manager = os.environ.get("INPUT_WINDOW_MANAGER", "")

--- a/tools/yaml-to-containerfile.py
+++ b/tools/yaml-to-containerfile.py
@@ -432,7 +432,7 @@ class ContainerfileGenerator:
             self.lines.append("    FEDORA_VERSION=$(rpm -E %fedora); \\")
             for repo in repos:
                 # Replace version placeholder
-                repo_url = repo.replace("43", "${FEDORA_VERSION}")
+                repo_url = repo.replace(self.context.fedora_version, "${FEDORA_VERSION}")
                 self.lines.append(f"    dnf install -y {repo_url}; \\")
 
         # Config manager
@@ -924,8 +924,8 @@ Examples:
     )
     parser.add_argument(
         "--fedora-version",
-        default="43",
-        help="Fedora version (default: 43, ignored for Linux bootc distros)",
+        default="",
+        help="Fedora version (default: from config, ignored for Linux bootc distros)",
     )
     parser.add_argument(
         "--enable-plymouth", action="store_true", default=True, help="Enable Plymouth"

--- a/yaml-definitions/sway.yml
+++ b/yaml-definitions/sway.yml
@@ -7,7 +7,7 @@ description: Custom Fedora bootc image with Sway desktop environment
 image-version: 43
 
 # Base image configuration
-base-image: quay.io/fedora/fedora-bootc:43
+base-image: quay.io/fedora/fedora-bootc
 image-type: fedora-bootc
 
 # Desktop environment selection


### PR DESCRIPTION
  - Make adnyeus.yml image-version the single source of truth for Fedora                                                                                                               
    version across resolve_build_config.py, urahara orchestrator, transpiler,                                                                                                          
    and generate-readme.py                                                                                                                                                             
  - Add systemd timers for flatpak auto-update (system + user scope)                                                                                                                 
  - Remove hardcoded "43" from 7 doc files                                                                                                                                             
