### PR TITLE
security: harden CI/CD with SHA pinning and refine blueprint modules

### DIFF
--- a/.github/workflows/hikifune.yml
+++ b/.github/workflows/hikifune.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: uv sync --dev
@@ -44,13 +44,13 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/hiyori.yml
+++ b/.github/workflows/hiyori.yml
@@ -40,7 +40,7 @@ jobs:
       enable_plymouth: ${{ steps.config.outputs.enable_plymouth }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Transpile YAML blueprint
         id: config
@@ -82,12 +82,12 @@ jobs:
           echo "image=${{ env.REGISTRY_URL }}/${OWNER}/${REPO}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
           driver-opts: image=moby/buildkit:v0.28.1  # Remediate CVE-2026-33747 (path traversal)
 
       - name: Login to GHCR for RPM overrides
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build and push
         id: build-push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: ${{ steps.config.outputs.containerfile }}
@@ -137,7 +137,7 @@ jobs:
       TRIVY_USERNAME: ${{ github.repository_owner }}
     steps:
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ${{ needs.build.outputs.image_ref }}:${{ needs.build.outputs.image_tag }}
           format: table
@@ -148,7 +148,7 @@ jobs:
 
       - name: Generate SBOM and submit to GitHub Dependency Graph
         if: github.ref == 'refs/heads/main'
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ${{ needs.build.outputs.image_ref }}:${{ needs.build.outputs.image_tag }}
           format: github
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload Trivy report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-image-scan-${{ needs.build.outputs.image_tag }}
           path: trivy-results.txt
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: always() && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-sbom-${{ needs.build.outputs.image_tag }}
           path: dependency-results.sbom.json
@@ -202,13 +202,13 @@ jobs:
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
       - name: Sign image with cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
       - run: |
           cosign sign --yes \
             --oidc-issuer=https://token.actions.githubusercontent.com \
@@ -224,7 +224,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -263,7 +263,7 @@ jobs:
 
       - name: Login to GHCR
         if: steps.version.outputs.skip != 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -287,7 +287,7 @@ jobs:
 
       - name: Sign release image with cosign
         if: steps.version.outputs.skip != 'true'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
       - if: steps.version.outputs.skip != 'true'
         run: |
           cosign sign --yes \

--- a/.github/workflows/kon.yml
+++ b/.github/workflows/kon.yml
@@ -31,16 +31,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/mayuri.yml
+++ b/.github/workflows/mayuri.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Fetch latest dotfiles commit SHA
         id: dotfiles

--- a/.github/workflows/nemu.yml
+++ b/.github/workflows/nemu.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/uhin.yml
+++ b/.github/workflows/uhin.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Verify required file structure
         run: |
@@ -64,20 +64,20 @@ jobs:
         uses: ./.github/actions/transpile
 
       - name: Hadolint
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: Dockerfile.generated
           ignore: DL3041,DL3059,DL4006,SC3040
 
       - name: Upload generated Containerfile
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: containerfile-generated
           path: Dockerfile.generated
           retention-days: 1
 
       - name: Checkov (Containerfile)
-        uses: bridgecrewio/checkov-action@v12
+        uses: bridgecrewio/checkov-action@3203f966a7ccd680cd8f6aaa3c3c5b0b3e9afa32 # v12
         with:
           file: Dockerfile.generated
           framework: dockerfile
@@ -86,7 +86,7 @@ jobs:
           skip_check: CKV_DOCKER_2,CKV_DOCKER_3
 
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: config
           scan-ref: .

--- a/.github/workflows/urahara.yml
+++ b/.github/workflows/urahara.yml
@@ -58,7 +58,7 @@ jobs:
     outputs:
       distro_version: ${{ steps.read.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: adnyeus.yml
           sparse-checkout-cone-mode: false

--- a/adnyeus.yml
+++ b/adnyeus.yml
@@ -231,9 +231,6 @@ modules:
       - src: overlays/base/systemd/system/bootc-fetch-apply-updates.timer.d/
         dst: /usr/lib/systemd/system/bootc-fetch-apply-updates.timer.d/
         mode: "0644"
-      - src: overlays/deploy/plane.env.example
-        dst: /etc/exousia/plane/plane.env
-        mode: "0644"
 
   # System services (common to all image types)
   # Note: All Quadlets are disabled by default (WantedBy commented out).


### PR DESCRIPTION
- Pin all GitHub Actions to full immutable SHAs in workflows and composite actions to prevent tag-to-hash substitution attacks and ensure build reproducibility.
- Refactor adnyeus.yml to remove the redundant plane.env.example mapping, as environment configuration is now handled differently.
- Clean up dangling  references in CI headers to align with the updated project theme.